### PR TITLE
Wrong variable validated

### DIFF
--- a/lib/zoomify/request.rb
+++ b/lib/zoomify/request.rb
@@ -55,7 +55,7 @@ module Zoomify
       def extract_response_vs_object response
         parsed_response = response.parsed_response
         unless parsed_response.blank?
-          hash = response.kind_of?(Hash) ? parsed_response : JSON.parse(parsed_response)
+          hash = parsed_response.kind_of?(Hash) ? parsed_response : JSON.parse(parsed_response)
           OpenStruct.new(hash)
         else
           yield

--- a/zoomify.gemspec
+++ b/zoomify.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_dependency "jwt"
-  spec.add_dependency "httparty", "~> 0.13.7"
+  spec.add_dependency "httparty", "~> 0.16.3"
 end


### PR DESCRIPTION
Fixing the name of the variable to be validated. It was validating response instead of parsed_response.
Also upgraded up the httparty version because it was old and was generating error with other modern gems.